### PR TITLE
Update End Point for HTTP Request

### DIFF
--- a/api-documentation/machines/set-access-for-user.md
+++ b/api-documentation/machines/set-access-for-user.md
@@ -7,7 +7,7 @@
 ```text
 # HTTP request:
 https://api.paperspace.io
-GET /machines/:machineId/setMachineAccessPublic?userId=u123abc
+GET /machines/:machineId/setMachineAccess?userId=u123abc
 x-api-key: 1ba4f98e7c0...
 # Returns 200 on success
 ```


### PR DESCRIPTION
The endpoint mentioned for the HTTP request is wrong. [https://docs.paperspace.com/paperspace-core-api/api-documentation/machines/set-access-for-user](https://docs.paperspace.com/paperspace-core-api/api-documentation/machines/set-access-for-user)

After spending almost an hour in figuring this out, I jumped into the NodeJs module of Paperspace, and saw that the actual endpoint name is not 'setMachineAccessPublic' but 'setMachineAccess'